### PR TITLE
Improve link to CPLEX setup using named anchor

### DIFF
--- a/documentation/basics/installation.md
+++ b/documentation/basics/installation.md
@@ -45,7 +45,7 @@ Note: Some special releases of ilastik are provided as a `.zip` file.  In that c
 
 -----------------
 
-## Automated Tracking Workflow Setup: CPLEX Installation and Setup
+## Automated Tracking Workflow Setup: CPLEX Installation and Setup<a name="cplex-setup"></a>
 
 To use the *Automatic Tracking* Workflow, it is required to install the commercial solver IBM CPLEX. 
 

--- a/documentation/tracking/tracking.md
+++ b/documentation/tracking/tracking.md
@@ -25,7 +25,7 @@ specific manual/semi-automatic or (fully) automatic tracking applets.
 
 **Please note that the _automatic_ tracking workflow only works on machines where CPLEX is installed
 additional to ilastik. Instructions on how to install CPLEX are given 
-[here]({{site.baseurl}}/documentation/basics/installation.html).**
+[here]({{site.baseurl}}/documentation/basics/installation.html#cplex-setup).**
 
 The manual tracking and automatic tracking workflows both build on the results of the
 [Pixel Classification workflow]({{site.baseurl}}/documentation/pixelclassification/pixelclassification.html).


### PR DESCRIPTION
That way, people coming from the tracking docs to the CPLEX installation instructions don't end up reading the ilastik installation instructions.