### PR TITLE
Jobs menu entry style

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -19,7 +19,7 @@
       <li {% if page.category == "Documentation" %} class="active" {% endif %}><a href="/documentation/index.html">Documentation</a></li>
       <li {% if page.category == "Development" %} class="active" {% endif %}><a href="/development.html">Development</a></li>
       <li {% if page.category == "Community" %} class="active" {% endif %}><a href="/community.html">Community</a></li>
-      <li class="active"><a href="http://hci.iwr.uni-heidelberg.de/Jobs/#software">Jobs</a></li>
+      <li><a href="http://hci.iwr.uni-heidelberg.de/Jobs/#software">Jobs</a></li>
       </ul>
     </div>
   </div>

--- a/documentation/basics/dataselection.md
+++ b/documentation/basics/dataselection.md
@@ -73,6 +73,15 @@ be included in the stack. The selection can be specified in three ways:
  * selecting all files in a directory
  * using a filename pattern (with [Unix style patterns](http://docs.python.org/2/library/glob.html))
 
+For image stacks saved in multiple .h5 files (HDF5, see paragraph [Supported
+File Formats](#formats)), an additional step has to be taken. HDF5 supports
+saving multiple datasets encapsulated in a single file which can be accessed
+using internal paths, similar to paths in a file system.
+Therefore, an internal path to the image data in each file has to be specified.
+Ilastik assumes that data with similar internal paths should be stacked and will
+try to find a common internal path in the selected .h5 files. In case of
+multiple common internal paths the user is asked to select the appropriate one.
+
 Once a selection has been made, the `File List` box can be used to review
 the names of the files that will be imported as an image stack.
 


### PR DESCRIPTION
The link always appeared "active". If highlighting is desired it should be achieved by an _appropriate_  style in css.