### PR TITLE
changed jobs menu entry style

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -19,7 +19,7 @@
       <li {% if page.category == "Documentation" %} class="active" {% endif %}><a href="/documentation/index.html">Documentation</a></li>
       <li {% if page.category == "Development" %} class="active" {% endif %}><a href="/development.html">Development</a></li>
       <li {% if page.category == "Community" %} class="active" {% endif %}><a href="/community.html">Community</a></li>
-      <li class="active"><a href="http://hci.iwr.uni-heidelberg.de/Jobs/#software">Jobs</a></li>
+      <li><a href="http://hci.iwr.uni-heidelberg.de/Jobs/#software">Jobs</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
The link always appeared "active". If highlighting is desired it should be achieved by an appropriate style in css.