### PR TITLE
Fix version number of MacOS binary downloads description to 1.2.2

### DIFF
--- a/download.html
+++ b/download.html
@@ -27,7 +27,7 @@ For help with installation, see the <a href="{{site.baseurl}}/documentation/basi
         <td><b>Supported Versions:</b> glibc 2.5 and up</td>
     </tr>
         <th><i class="fa fa-apple fa-lg"></i>&nbsp;Mac (64-bit), OSX</th>
-        <td><a href="http://files.ilastik.org/ilastik-1.2.2rc4-OSX.tar.bz2">version 1.2.1rc4 (2017-06-01) </a></td>
+        <td><a href="http://files.ilastik.org/ilastik-1.2.2rc4-OSX.tar.bz2">version 1.2.2rc4 (2017-06-01) </a></td>
         <td><b>Supported Versions:</b> Mountain Lion 10.8 and up</td>
     </tr>
 </tbody>
@@ -51,7 +51,7 @@ Previous stable version:
         <td><b>Supported Versions:</b> glibc 2.5 and up</td>
     </tr>
         <th><i class="fa fa-apple fa-lg"></i>&nbsp;Mac (64-bit), OSX</th>
-        <td><a href="http://files.ilastik.org/ilastik-1.2.2rc1-OSX.tar.bz2">version 1.2.1 (2017-05-11) </a></td>
+        <td><a href="http://files.ilastik.org/ilastik-1.2.2rc1-OSX.tar.bz2">version 1.2.2rc1 (2017-05-11) </a></td>
         <td><b>Supported Versions:</b> Mountain Lion 10.8 and up</td>
     </tr>
 </tbody>


### PR DESCRIPTION
Fix was needed in description only, the link was correct.