### PR TITLE
Enh add gurobi instructions

### DIFF
--- a/documentation/basics/installation.md
+++ b/documentation/basics/installation.md
@@ -9,36 +9,41 @@ weight: 0
 
 # Installation
 
-ilastik binaries are provided for for Linux, Mac and Windows at our [download page]({{site.baseurl}}/download.html).
+ilastik binaries are provided for Windows, Linux, and Mac at our [download page]({{site.baseurl}}/download.html).
 
 **Note: ilastik requires a 64-bit machine.  We do not provide 32-bit binaries.**
 
 Most workflows are available with the [basic ilastik installation](#basic-installation).
+
 Some workflows, however, require the manual installation of a commercial solver.
-On Windows, the following workflows will only be available after installing the IBM CPLEX solver:
+On *Windows*, the following workflows will only be available after installing the IBM CPLEX solver:
 
 + Boundary Segmentation with Multicut
 + Tracking (all flavours)
 + Counting (better results with CPLEX)
 
-On MacOs and Linux only Learning in the Tracking workflow *requires* a commercial solver (CPLEX or Gurobi).
-However, the The Boundary Segmentation with Multicut, and the Tracking workflow
+In order to enable these workflows, please follow the instructions in the section about [commercial solver installation](#solver-setup).
+
+On *Mac* and *Linux* only Learning in the Tracking workflow *requires* a commercial solver (CPLEX or Gurobi).
+Furthermore, the results of the Boundary Segmentation with Multicut and the Tracking workflow tend to be more accurate using one of the two commercial solvers.
+
 
 ## Basic Installation <a id="basic-installation"></a>
 
-### Windows
+### Installation on Windows
 
 [Download]({{site.baseurl}}/download.html) the Windows self-extracting installer and run it.
 The installer will guide you through the installation process.
 You can find an entry for ilastik in the start menu and click it to launch the program.
 
 
-### MacOs
+### Installation on Mac
 
 [Download]({{site.baseurl}}/download.html) the `.tar.bz2` file for your version of OSX and extract its contents with a simple double-click.
 Copy ilastik.app to the folder of your choice (usually your `Applications` folder), and double-click to begin.
 
-### Linux
+
+### Installation on Linux
 
 [Download]({{site.baseurl}}/download.html) the Linux `.tar.bz2` bundle and extract its contents from the terminal:
 
@@ -54,99 +59,104 @@ To run ilastik, use the included `run_ilastik.sh` script:
 
 -----------------
 
-## Automated Tracking Workflow Setup: CPLEX Installation and Setup<a name="cplex-setup"></a>
+## Commercial Solver Installation <a name="solver-setup"></a>
 
-To use the *Automatic Tracking* Workflow, it is required to install the commercial solver IBM CPLEX. 
+For some workflows in ilastik, installation of a commercial solver is required.
+*IBM CPLEX* is supported by ilastik on all platforms.
+Alternatively, *GUROBI* can be used on Linux and Mac.
 
-**Note that ilastik will run even without IBM CPLEX installed, it is only a requirement for the [Automatic Tracking]({{baseurl}}/documentation/tracking/tracking.html) workflow.
-To enable additional functionality, it is also recommended for the [Density Counting]({{baseurl}}/documentation/counting/counting.html) workflow.**
+### CPLEX Installation and Setup
 
-### Application for Academic License at IBM
+#### Application for Academic License at IBM
 
 IBM CPLEX is a commercial solver which is free for academic use.
-To apply for an academic license, the user first needs to apply for an 
-academic membership at IBM. Details may be found on
-[the IBM Academic Initiative website](http://www-03.ibm.com/ibm/university/academic/pub/page/membership).
+Details on the application for an academic license, may be found on
+[the IBM Academic Initiative website](https://developer.ibm.com/academic/).
 Please note that it might take some days until the application gets approved by IBM.
 
-### Download IBM CPLEX
+#### Download IBM CPLEX
 
-After the academic membership has been approved, the user can download IBM CPLEX. To do so, 
-the steps on [this IBM website](http://www-03.ibm.com/ibm/university/academic/pub/jsps/assetredirector.jsp?asset_id=1070)
-may be followed. 
-The search result in the IBM software catalogue should look similar to this:
+Once the license has been approved by IBM, instructions for download will be provided.
 
-<a href="./fig/ibm_search_result.jpg" data-toggle="lightbox">
-<img src="./fig/ibm_search_result.jpg" class="img-responsive"></a>
-
-We recommend to use *Http transfer*, then clicking on the CPLEX instance in *Industry Solutions* should open
-a list of CPLEX versions available for different platforms:
-
-<a href="./fig/cplex_result.jpg" data-toggle="lightbox">
-<img src="./fig/cplex_result.jpg" class="img-responsive"></a>
-
-The current version of ilastik works with 
-**IBM ILOG CPLEX Optimization Studio V12.5.1**.
-After choosing the appropriate platform, the user has to agree with the IBM license. 
+The current version of ilastik works with
+**IBM ILOG CPLEX Optimization Studio V12.6**.
+After choosing the appropriate platform, you have to agree with the IBM license.
 Finally, CPLEX may be downloaded and is ready to install.
 
 **Important note: It is not sufficient to download the Trial version of CPLEX since its solver can only handle
 very small problem sizes. Please make sure, the correct version is downloaded as described here.**
 
-### Windows
+The following sections contain platform-specific instructions for CPLEX installation on [Windows](#cplex-setup-windows) as well as on [Linux and Mac](#cplex-setup-linux-mac).
+
+#### Setup on Windows <a name="cplex-setup-windows"></a>
 
 Run the installer by double clicking the executable that you've downloaded.
 
-On Windows, there are typically no further modifications needed after installing CPLEX. 
-After successful installation, the *Automatic Tracking Workflow* is displayed on the Start-Screen of ilastik.
+On Windows, there are typically no further modifications needed after installing CPLEX.
+After successful installation the *Automatic Tracking Workflow* is displayed on the Start-Screen of ilastik.
 
-If this workflow is not present, something went wrong with the CPLEX installation. To track down the problem, proceed like this:
-* Make sure that the environment variable `CPLEX_STUDIO_DIR1251` is set and points to the proper location. You can check this by typing `echo %CPLEX_STUDIO_DIR1251%` at the DOS command prompt. The output should be something like `C:\Program Files\IBM\ILOG\CPLEX_Studio1251`.
-* Make sure that `cplex` is in the PATH. Type `where cplex` at a DOS prompt. It should produce something like `C:\Program Files\ibm\ILOG\CPLEX_Studio1251\cplex\bin\x64_win64\cplex.exe` (the path prefix should match the contents of the `CPLEX_STUDIO_DIR1251` variable).
-* Make sure that the directory containing `cplex.exe` also contains `cplex1251.dll`, `ILOG.CPLEX.dll`, and `ILOG.Concert.dll`. 
+If this workflow is not present, something went wrong with the CPLEX installation.
+To track down the problem, proceed like this:
 
-The *Automatic Tracking Workflow* should now be displayed on the start screen. If it doesn't, you may copy the files `cplex1251.dll`, `ILOG.CPLEX.dll`, and `ILOG.Concert.dll` (if you can locate them somewhere) to the *binary* folder of the ilastik installation, usually located at `C:\Program Files\ilastik\bin`. If it still doesn't work, please contact us.
+* Make sure that the environment variable `CPLEX_STUDIO_DIR1263` is set and points to the proper location.
+  You can check this by typing `echo %CPLEX_STUDIO_DIR1263%` at the DOS command prompt.
+  The output should be something like `C:\Program Files\IBM\ILOG\CPLEX_Studio1263`.
+* Make sure that `cplex` is in the PATH.
+  Type `where cplex` at a DOS prompt.
+  It should produce something like `C:\Program Files\ibm\ILOG\CPLEX_Studio1263\cplex\bin\x64_win64\cplex.exe` (the path prefix should match the contents of the `CPLEX_STUDIO_DIR1263` variable).
+* Make sure that the directory containing `cplex.exe` also contains `cplex1263.dll`, `ILOG.CPLEX.dll`, and `ILOG.Concert.dll`.
+
+The *Automatic Tracking Workflow* should now be displayed on the start screen.
+If it doesn't, you may copy the files `cplex1263.dll`, `ILOG.CPLEX.dll`, and `ILOG.Concert.dll` (if you can locate them somewhere) to the *binary* folder of the ilastik installation, usually located at `C:\Program Files\ilastik\bin`.
+If it still doesn't work, please [contact us]({{site.baseurl}}/community.html).
 
 
-### Linux and Mac
+#### Setup on Linux and Mac<a name="cplex-setup-linux-mac"></a>
 
-#### CPLEX Installation
-
-On Linux and Mac, the CPLEX installer comes as a commandline executable (`cplex-someversion.sh` on Linux and `cplex-someversion.bin`). 
+On Linux and Mac, the CPLEX installer comes as a commandline executable (`cplex-someversion.sh` on Linux and `cplex-someversion.bin` on Mac).
 To install it, open a terminal and run `bash /path/to/your/cplex-someversion.sh` (or `bash /path/to/your/cplex-someversion.bin` on Mac).
 
-**Hint:** on Mac and most Linux distributions you can drag and drop the installer file into the terminal to get the full path appended to your command line. 
-
-#### Adding CPLEX to ilastik
+**Hint:** on Mac and most Linux distributions you can drag and drop the installer file into the terminal to get the full path appended to your command line.
 
 CPLEX packages for Linux and Mac do not provide shared versions of all required libraries, but only static variants.
-
+In order to enable CPLEX with ilastik, the static libraries have to be converted.
 Before you can convert your static CPLEX libraries into shared library versions, you need to have a compiler installed on your machine.
-
 You can check whether you already have a compiler installed by running the following command in a terminal (open the Terminal app!).
-    
+
     gcc --version
 
 If no compiler is installed, choose what to do depending on your OS version:
 
 - For Linux, use your OS package manager (e.g. `apt-get`) to install the `gcc` package.
-- For all OSX < 10.9, so up to Mountain Lion, you need to install XCode from the AppStore. Then you need to go to XCode's Preferences, to the Downloads tab, and install the command line tools.
+- For all OSX < 10.9, so up to Mountain Lion, you need to install XCode from the AppStore.
+  Then you need to go to XCode's Preferences, to the Downloads tab, and install the command line tools.
 - For OSX 10.9 Mavericks it suffices to install the command line tools using the following command without installing XCode.
 
       xcode-select --install
 
   Then you need to accept the XCode licence by running "sudo gcc" once.
 
-Now you can download and execute a [script][] that will convert your CPLEX static libraries into shared libraries, and install them into the appropriate directory of your ilastik directory.
+Now you can run a script, that will convert your CPLEX static libraries into shared libraries, and install them into the appropriate directory of your ilastik directory.
+Starting with ilastik-1.1.7, this script can be found in ilastik-1.\*/ilastik-meta/ilastik/scripts.
+Prior to that version the [script](https://github.com/ilastik/ilastik/blob/master/scripts/install-cplex-shared-libs.sh) needs to be downloaded manually in the terminal:
 
-    # Download
-    # (Starting with ilastik-1.1.7, this script can be found in ilastik-1.1.7/ilastik-meta/ilastik/scripts)
     wget https://raw.githubusercontent.com/ilastik/ilastik/master/scripts/install-cplex-shared-libs.sh
-    
+
+Navigate to the directory containing the script and execute it:
+
+    # navigate to the script location, e.g. /path/to/ilastik-1.*-Linux/ilastik-meta/ilastik/scripts
+    cd /path/to/script
     # Linux:
-    bash install-cplex-shared-libs.sh /path/to/your/cplex-root-dir /path/to/ilastik-1.X.Y-Linux
+    bash install-cplex-shared-libs.sh /path/to/your/cplex-root-dir /path/to/ilastik-1.*-Linux
     # Mac:
-    bash install-cplex-shared-libs.sh /path/to/your/cplex-root-dir /path/to/ilastik-1.X.Y-OSX.app
+    bash install-cplex-shared-libs.sh /path/to/your/cplex-root-dir /path/to/ilastik-1.*-OSX.app
+
+In the command above, `/path/to/your/cplex-root-dir` is the location of your cplex studio installation. It should contain directories named `concert` and `cplex`, among others.
+
+**Note:** The above script installs CPLEX directly into your ilastik installation.
+Once you've done that, you should not distribute your copy of ilastik to others, unless you have a license to distribute CPLEX.
+
+After a successful installation, the *Tracking with Learning Workflow* will appear on the Start-Screen of ilastik.
 
 In the command above, `cplex-root-dir` is the location of your cplex studio installation. It should contain directories named `concert` and `cplex`, among others.
 

--- a/documentation/basics/installation.md
+++ b/documentation/basics/installation.md
@@ -1,30 +1,46 @@
 ---
 layout: documentation
 title: Installation
-tagline: 
+tagline:
 category: "Documentation"
 group: "basic-documentation"
 weight: 0
 ---
 
-# Basic Installation
+# Installation
 
-Most workflows do not require any special install instructions.  Follow these steps to get started right away.
-
-To use the [Automated Tracking Workflow]({{baseurl}}/documentation/tracking/tracking.html), you will need to 
-install CPLEX separately, and then follow a special procedure to enable ilastik to use it.  
-See the special instructions below for details.
+ilastik binaries are provided for for Linux, Mac and Windows at our [download page]({{site.baseurl}}/download.html).
 
 **Note: ilastik requires a 64-bit machine.  We do not provide 32-bit binaries.**
 
-### Mac
+Most workflows are available with the [basic ilastik installation](#basic-installation).
+Some workflows, however, require the manual installation of a commercial solver.
+On Windows, the following workflows will only be available after installing the IBM CPLEX solver:
 
-[Download]({{site.baseurl}}/download.html) the `.zip` file for your version of OSX and extract its contents with a simple double-click.  
-Copy ilastik.app to the folder of your choice (usually your `Applications` folder), and double-click to begin. 
++ Boundary Segmentation with Multicut
++ Tracking (all flavours)
++ Counting (better results with CPLEX)
+
+On MacOs and Linux only Learning in the Tracking workflow *requires* a commercial solver (CPLEX or Gurobi).
+However, the The Boundary Segmentation with Multicut, and the Tracking workflow
+
+## Basic Installation <a id="basic-installation"></a>
+
+### Windows
+
+[Download]({{site.baseurl}}/download.html) the Windows self-extracting installer and run it.
+The installer will guide you through the installation process.
+You can find an entry for ilastik in the start menu and click it to launch the program.
+
+
+### MacOs
+
+[Download]({{site.baseurl}}/download.html) the `.tar.bz2` file for your version of OSX and extract its contents with a simple double-click.
+Copy ilastik.app to the folder of your choice (usually your `Applications` folder), and double-click to begin.
 
 ### Linux
 
-[Download]({{site.baseurl}}/download.html) the Linux `.tar.bz2` bundle and extract its contents:
+[Download]({{site.baseurl}}/download.html) the Linux `.tar.bz2` bundle and extract its contents from the terminal:
 
     tar xjf ilastik-1.*-Linux.tar.bz2
 
@@ -33,13 +49,6 @@ To run ilastik, use the included `run_ilastik.sh` script:
     cd ilastik-1.*-Linux
     ./run_ilastik.sh
 
-### Windows
-
-[Download]({{site.baseurl}}/download.html) the Windows self-extracting installer and run it.
-The installer will guide you through the installation process.
-
-Note: Some special releases of ilastik are provided as a `.zip` file.  In that case, extract the 
-`.zip` file to the location of your choice and run the enclosed `ilastik.bat` script to launch the program.
 
 -----------------
 

--- a/documentation/basics/installation.md
+++ b/documentation/basics/installation.md
@@ -158,10 +158,64 @@ Once you've done that, you should not distribute your copy of ilastik to others,
 
 After a successful installation, the *Tracking with Learning Workflow* will appear on the Start-Screen of ilastik.
 
-In the command above, `cplex-root-dir` is the location of your cplex studio installation. It should contain directories named `concert` and `cplex`, among others.
+----------
 
-**Note:** The above script installs CPLEX directly into your ilastik installation.  Once you've done that, you should not distribute your copy of ilastik to others, unless you have a license to distribute CPLEX.
+### GUROBI Installation and Setup
 
-[script]: https://github.com/ilastik/ilastik/blob/master/scripts/install-cplex-shared-libs.sh
+On Linux and Mac, a second commercial solver, GUROBI, is supported.
+As with CPLEX, a free academic license can be obtained for GUROBI.
 
-After a successful installation, the *Automatic Tracking Workflow* will appear on the Start-Screen of ilastik.
+#### Application for Academic License at GUROBI
+
+Application for an academic license is available after registration with your institution email address at the [GUROBI website](https://www.gurobi.com/).
+Details can be found [here](https://www.gurobi.com/academia/for-universities).
+The easiest way is to obtain a free named-user academic license.
+Instructions are provided on [this page](https://www.gurobi.com/academia/for-universities).
+At the end of the process, you will be provided with your license key.
+You will need the license key to activate your GUROBI installation.
+
+#### Installation
+
+Download the appropriate package from the [GUROBI download page](https://www.gurobi.com/downloads/gurobi-optimizer).
+Unpack the downloaded archive:
+
+    tar -xvf gurobi7.0.2_linux64.tar.gz -C /your/target/directory
+
+And activate your installation by invoking `grbgetkey` with your license:
+
+    cd /your/target/directory/gurobi702/linux64/bin
+    # use the obtained license key here
+    ./grbgetkey your-license-key-here
+    # Follow the instructions and take note of the license path.
+
+In the next step you have to execute a script that will link your GUROBI libraries to your ilastik installation.
+The script can be found in `your-ilastik-installation-folder/ilastik-meta/ilastik/scripts`.
+With versions prior to ilastik-1.1.7, this [script](https://raw.githubusercontent.com/ilastik/ilastik/master/scripts/install-gurobi-symlinks.sh) is not included and has to be downloaded manually:
+
+    wget https://raw.githubusercontent.com/ilastik/ilastik/master/scripts/install-gurobi-symlinks.sh
+
+Navigate to the script directory and run it:
+
+    # the following line is only necessary if you have used a custom location for the
+    # license file when invoking `grbgetkey`
+    export GRB_LICENSE_FILE=/path/to/license/gurobi.lic
+
+    # navigate to the script location, e.g. /path/to/ilastik-1.*-Linux/ilastik-meta/ilastik/scripts
+    cd /path/to/script
+    # Linux:
+    bash install-gurobi-symlinks.sh /your/target/directoy/gurobi702/linux64 /path/to/ilastik-1.*-Linux
+    # Mac:
+    bash install-gurobi-symlinks.sh /your/target/directoy/gurobi702/linux64/ /path/to/ilastik-1.*-OSX.app
+
+In order to run ilastik with GUROBI support, make sure to always set the path to the license file (in case of a non-standard location):
+
+    # set-up environment
+    export GRB_LICENSE_FILE=/path/to/license/gurobi.lic
+
+    # run ilastik
+    cd /path/to/ilastik-1.*-Linux
+    ./run_ilastik.sh
+
+After a successful installation, the *Tracking with Learning Workflow* will appear on the Start-Screen of ilastik.
+
+Should you run into any problems, please [contact us]({{site.baseurl}}/community.html).

--- a/documentation/basics/installation.md
+++ b/documentation/basics/installation.md
@@ -24,8 +24,8 @@ On *Windows*, the following workflows will only be available after installing th
 
 In order to enable these workflows, please follow the instructions in the section about [commercial solver installation](#solver-setup).
 
-On *Mac* and *Linux* only Learning in the Tracking workflow *requires* a commercial solver (CPLEX or Gurobi).
-Furthermore, the results of the Boundary Segmentation with Multicut and the Tracking workflow tend to be more accurate using one of the two commercial solvers.
+On *Mac* and *Linux* only Learning the weights in the Tracking with Learning Workflow *requires* a commercial solver (CPLEX or Gurobi).
+Furthermore, the results of the Boundary Segmentation with Multicut Workflow and the Tracking Workflow tend to be more accurate using one of the two commercial solvers.
 
 
 ## Basic Installation <a id="basic-installation"></a>
@@ -216,6 +216,6 @@ In order to run ilastik with GUROBI support, make sure to always set the path to
     cd /path/to/ilastik-1.*-Linux
     ./run_ilastik.sh
 
-After a successful installation, the *Tracking with Learning Workflow* will appear on the Start-Screen of ilastik.
+After a successful installation, learning the weights in the *Tracking with Learning Workflow* will be enabled.
 
 Should you run into any problems, please [contact us]({{site.baseurl}}/community.html).


### PR DESCRIPTION
Reworked the whole installation page and added instructions for GUROBI installation on Linux and Mac

Fixes #31 