### PR TITLE
Add link to new image.sc forum

### DIFF
--- a/community.html
+++ b/community.html
@@ -12,12 +12,9 @@ If you want to report bugs or request new features, please
 use our <a href="http://github.com/ilastik/ilastik/issues">issue tracker</a> on github.
 </p>
 
-
-    <p>
-    For user discussions and support, please use the mailinglist <a href="https://mail.iwr.uni-heidelberg.de/services/mailman/listinfo/ilastik-user">ilastik-user</a>. <br> 
-    You don't have to become a member to write to this list.
-    </p>
-
+<p>
+For user discussions and support, please use the <a href="https://forum.image.sc/tags/ilastik">image.sc forum</a> (tagging your posts with <code>ilastik</code>).
+</p>
 
 <p>
 If you have special requests or need help, contact the friendly Ilastik team


### PR DESCRIPTION
Ilastik is an official partner of the Image.sc forum, so let's recommend the forum as the primary place to ask questions.