### PR TITLE
Some more documentation on the headless mode.

### DIFF
--- a/documentation/basics/headless.md
+++ b/documentation/basics/headless.md
@@ -103,7 +103,7 @@ the command (as shown in the example above).
 - `--output_axis_order` Transpose the storage order of the results. For example, this affects the sliced dimension for stack outputs.
 - `--pipeline_result_drange` Pipeline result data range (min,max) BEFORE normalization, e.g. `"(0.0,1.0)"`
 - `--export_drange` Exported data range (min,max) AFTER normalization, e.g. `"(0,255)"`
-- `--readOnly=1` Open project in read-only mode to allow multiple processing accessing the same file.
+- `--readonly` Open the project in read-only mode; necessary for using a single project from multiple processes.
 
 [Data Export Applet]: {{site.baseurl}}/documentation/basics/export.html#data-export-applet-ss
 

--- a/documentation/basics/headless.md
+++ b/documentation/basics/headless.md
@@ -103,6 +103,7 @@ the command (as shown in the example above).
 - `--output_axis_order` Transpose the storage order of the results. For example, this affects the sliced dimension for stack outputs.
 - `--pipeline_result_drange` Pipeline result data range (min,max) BEFORE normalization, e.g. `"(0.0,1.0)"`
 - `--export_drange` Exported data range (min,max) AFTER normalization, e.g. `"(0,255)"`
+- `--readOnly=1` Open project in read-only mode to allow multiple processing accessing the same file.
 
 [Data Export Applet]: {{site.baseurl}}/documentation/basics/export.html#data-export-applet-ss
 

--- a/documentation/basics/headless.md
+++ b/documentation/basics/headless.md
@@ -229,7 +229,7 @@ For developers and power-users, you can run your own ilastik-dependent python sc
     # Mac
     $ ./ilastik-1.3.2-OSX.app/Contents/ilastik-release/bin/python -c "import ilastik; print ilastik.__version__"
     1.3.2
-
+Check out [this example](https://github.com/ilastik/ilastik/blob/master/examples/example_python_client.py) on how to use ilastik as a python module
 ## Known Issues
 
 ilastik's headless mode will sometimes throw exceptions and output a stack trace instead of letting you known why your command line arguments are wrong. Though those issues are being worked on, here are some hints and workarounds you can use to get by:

--- a/documentation/basics/headless.md
+++ b/documentation/basics/headless.md
@@ -229,7 +229,6 @@ For developers and power-users, you can run your own ilastik-dependent python sc
     # Mac
     $ ./ilastik-1.3.2-OSX.app/Contents/ilastik-release/bin/python -c "import ilastik; print ilastik.__version__"
     1.3.2
-Check out [this example](https://github.com/ilastik/ilastik/blob/master/examples/example_python_client.py) on how to use ilastik as a python module
 ## Known Issues
 
 ilastik's headless mode will sometimes throw exceptions and output a stack trace instead of letting you known why your command line arguments are wrong. Though those issues are being worked on, here are some hints and workarounds you can use to get by:


### PR DESCRIPTION
- Add ReadOnly=1 option
- Add Link to the python client example included in ilastik.