### PR TITLE
Fix navbar wrapping on certain screen sizes

### DIFF
--- a/assets/ilastik.css
+++ b/assets/ilastik.css
@@ -114,3 +114,45 @@ h2:hover .header-link {
 .news-frontpage-badge {
   text-align: center;
 }
+
+/*
+ * Collapse the navbar on wider screens to avoid wrapping it's contents to the second row.
+ * See https://stackoverflow.com/a/20249415.
+ */
+@media (max-width: 991px) {
+  .navbar-header {
+      float: none;
+  }
+  .navbar-toggle {
+      display: block;
+  }
+  .navbar-collapse {
+      border-top: 1px solid transparent;
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.1);
+  }
+  .navbar-collapse.collapse {
+      display: none!important;
+  }
+  .navbar-nav {
+      float: none!important;
+      margin: 7.5px -15px;
+  }
+  .navbar-nav>li {
+      float: none;
+  }
+  .navbar-nav>li>a {
+      padding-top: 10px;
+      padding-bottom: 10px;
+  }
+  .navbar-text {
+      float: none;
+      margin: 15px 0;
+  }
+  /* since 3.1.0 */
+  .navbar-collapse.collapse.in {
+      display: block!important;
+  }
+  .collapsing {
+      overflow: hidden!important;
+  }
+}


### PR DESCRIPTION
Collapse the navbar on wider screens to avoid wrapping it's contents to the second row.
See https://stackoverflow.com/a/20249415.

Close #99.