### PR TITLE
Add Bootstrap classes to Markdown tables

### DIFF
--- a/documentation/animalTracking/animalTracking.md
+++ b/documentation/animalTracking/animalTracking.md
@@ -120,12 +120,13 @@ Unlike the pixel classification workflow, you will not draw labels will the brus
 
 Try to find and label a few of these objects on your video. You can also check the `Live Update` option to get live feedback of the object predictions. Here's a few examples of labelled objects:
 
-| Object Label | Screenshot |
-| ---- | ---------- |
+{:.table.table-striped}
+| Object Label    | Screenshot                                                                                                    |
+|-----------------|---------------------------------------------------------------------------------------------------------------|
 | False Detection | <a href="./fig/0merger.png" data-toggle="lightbox"><img src="./fig/0merger.png" class="img-responsive" /></a> |
-| 1 Object | <a href="./fig/1merger.png" data-toggle="lightbox"><img src="./fig/1merger.png" class="img-responsive" /></a> |
-| 2 Objects | <a href="./fig/2merger.png" data-toggle="lightbox"><img src="./fig/2merger.png" class="img-responsive" /></a> |
-| 3 OBjects | <a href="./fig/3merger.png" data-toggle="lightbox"><img src="./fig/3merger.png" class="img-responsive" /></a> |    
+| 1 Object        | <a href="./fig/1merger.png" data-toggle="lightbox"><img src="./fig/1merger.png" class="img-responsive" /></a> |
+| 2 Objects       | <a href="./fig/2merger.png" data-toggle="lightbox"><img src="./fig/2merger.png" class="img-responsive" /></a> |
+| 3 Objects       | <a href="./fig/3merger.png" data-toggle="lightbox"><img src="./fig/3merger.png" class="img-responsive" /></a> |
   
 Sometimes it's difficult to find clusters of 2 or more objects, since these can be very sparse. 
 For these cases, click on the `Label Assist` button, and then click on the `Compute Object Info` button which will display a table where you can sort frames by maximum and minimum object area.
@@ -137,17 +138,18 @@ After you trained the object count classifier, click on the `Tracking` section o
 This is the main section of the tracking workflow, where the object IDs will be assigned. 
 Here's a list of relevant parameters with a brief explanation:    
 
-| Parameter | Description |
-| ---------- | ----------- |
-| Max Distance | Maximum distance to consider when finding nearest neighbors (for frame-to-frame transitions). |
-| Max Object per Merger | Maximum number of objects allowed on a cluster (this value is set automatically, don't change it if you don't have to) |
-| Transition Weight | Weight based on the distance between objects (for frame-to-frame transitions). |
-| Appearance Cost | Costs to allow object IDs to appear (to start a new track). High values (>5000) forbid objects appearances, and could be helpful with a high-quality segmentation and the same number of objects in all frames. |
-| Disappearance Cost | Cost to allow object Ids to dissapear (to terminate an existing track). High values (>5000) will forbid object disappearances. |
-| Transition Neighbours | Number of neighbors to be considered as potential transition candiadates. Less neighbors speed up running-time, but the results might be of a lesser quality. |
-| Frames per Split | When the videos have too many frames (eg. > 10000), it is heplful to split the video in parts in order to improve the running-time. The recommended value would be ~1000 frames. Use 0 if you don't want to use splits. | 
-| With Tracklets | Compress stable tracks to improve the running-time (objects with only one transition possiblity) |
-| Filters | Range filters for time, X, Y, and Z axes, and for size. Objects outside of these ranges will be ignored. |
+{:.table.table-striped}
+| Parameter             | Description                                                                                                                                                                                                             |
+|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Max Distance          | Maximum distance to consider when finding nearest neighbors (for frame-to-frame transitions).                                                                                                                           |
+| Max Object per Merger | Maximum number of objects allowed on a cluster (this value is set automatically, don't change it if you don't have to)                                                                                                  |
+| Transition Weight     | Weight based on the distance between objects (for frame-to-frame transitions).                                                                                                                                          |
+| Appearance Cost       | Costs to allow object IDs to appear (to start a new track). High values (>5000) forbid objects appearances, and could be helpful with a high-quality segmentation and the same number of objects in all frames.         |
+| Disappearance Cost    | Cost to allow object Ids to dissapear (to terminate an existing track). High values (>5000) will forbid object disappearances.                                                                                          |
+| Transition Neighbours | Number of neighbors to be considered as potential transition candiadates. Less neighbors speed up running-time, but the results might be of a lesser quality.                                                           |
+| Frames per Split      | When the videos have too many frames (eg. > 10000), it is heplful to split the video in parts in order to improve the running-time. The recommended value would be ~1000 frames. Use 0 if you don't want to use splits. |
+| With Tracklets        | Compress stable tracks to improve the running-time (objects with only one transition possiblity)                                                                                                                        |
+| Filters               | Range filters for time, X, Y, and Z axes, and for size. Objects outside of these ranges will be ignored.                                                                                                                |
 
 <a href="./fig/trackingTracking.png" data-toggle="lightbox"><img src="./fig/trackingTracking.png" class="img-responsive" /></a>
 
@@ -156,21 +158,22 @@ Here's a list of relevant parameters with a brief explanation:
 You could start with the default parameter values, or experiment with different values for difficult cases with multiple appearances, disappearances, and mergers.
 Here is a table with the values that are recommended for this example (most are left with their default values):
 
-| Parameter | Value |
-| --------- | ----- |
-| Max Distance | 200 (default) |
-| Max Object per Merger | 3 (automatic) |
-| Transition Weight | 10.0 (default) |
-| Appearance Cost | 500 (default) |
-| Disappearance Cost | 500 (default) |
-| Transition Neighbours | 1 (default) |
-| Frames per Split | 0 (default) |
-| With Tracklets | False |  
-| Filters>Time | 0 to 100 |
-| Filters>X | 0 to 1023 (default) |
-| Filters>Y | 0 to 1023 (default) |
-| Filters>Z | 0 to 0 (default) |
-| Filters>Size | 15 to 10000 |  
+{:.table.table-striped}
+| Parameter             | Value               |
+|-----------------------|---------------------|
+| Max Distance          | 200 (default)       |
+| Max Object per Merger | 3 (automatic)       |
+| Transition Weight     | 10.0 (default)      |
+| Appearance Cost       | 500 (default)       |
+| Disappearance Cost    | 500 (default)       |
+| Transition Neighbours | 1 (default)         |
+| Frames per Split      | 0 (default)         |
+| With Tracklets        | False               |
+| Filters>Time          | 0 to 100            |
+| Filters>X             | 0 to 1023 (default) |
+| Filters>Y             | 0 to 1023 (default) |
+| Filters>Z             | 0 to 0 (default)    |
+| Filters>Size          | 15 to 10000         |
   
 The video will be running optimization based on the transition, appearance, and disappearance costs across frames in order to assign the correct IDs for each object. 
 

--- a/documentation/tracking/tracking.md
+++ b/documentation/tracking/tracking.md
@@ -291,20 +291,20 @@ the most probable tracking solution for the model constructed, i.e. it tries to 
 Although the tracking result should usually be already sufficient with the default values, we now briefly give explanations
 for the **parameters** our tracking algorithm uses (see [\[1\]](#ref_conservation) for more details). 
 
-| Parameter       | Description
-|:---------------| :-------------------------
-| Max. Object per Merger | Defines how many objects could be contained in a single cluster. Should correspond to the max label in the Object Count applet.
-| Division weight | Cost to allow one object to divide
-| Transition weight | Costs to allow one object to be assigned to another
-| Appearance cost  | Costs to allow one object to appear, i.e. to start a new track other than at the beginning of the time range or the borders of the field of view. High values (&ge;1000) forbid object appearances if possible.
-| Disappearance cost  | Costs to allow one object to disappear, i.e. to terminate an existing track other than at the end of the time range or the borders of the field of view. High values (&ge;1000) forbid object disappearances if possible.
-| Timeout in sec.  | Timeout in seconds for the optimization. Leave empty for not specifying a timeout (then, the best solution will be found no matter how long it takes).
-| Border width | The border pixels have to be treated in a special way for appearance/disappearance
-| Transition neighborhood | How far can an object move
-| Frames per split | By default (0) the tracking is done globally over the whole time range. By specifying a non-zero number here, you break your video up into pieces of this length and then solve hierarchically and in parallel. This is much faster than no splitting for long videos
-| Solver | Flow-based, as described [here](https://link.springer.com/chapter/10.1007/978-3-319-46478-7_35) or ILP, which requires commercial solvers. Flow-based gives excellent tracking solutions and is much faster than ILP, which we keep for consistency with older projects
-| Divisible Objects | Check if the objects may divide over time, e.g. when tracking proliferating cells. Consider using the animal tracking workflow if they don't.
-
+{:.table.table-striped}
+| Parameter               | Description                                                                                                                                                                                                                                                             |
+|:------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Max. Object per Merger  | Defines how many objects could be contained in a single cluster. Should correspond to the max label in the Object Count applet.                                                                                                                                         |
+| Division weight         | Cost to allow one object to divide                                                                                                                                                                                                                                      |
+| Transition weight       | Costs to allow one object to be assigned to another                                                                                                                                                                                                                     |
+| Appearance cost         | Costs to allow one object to appear, i.e. to start a new track other than at the beginning of the time range or the borders of the field of view. High values (&ge;1000) forbid object appearances if possible.                                                         |
+| Disappearance cost      | Costs to allow one object to disappear, i.e. to terminate an existing track other than at the end of the time range or the borders of the field of view. High values (&ge;1000) forbid object disappearances if possible.                                               |
+| Timeout in sec.         | Timeout in seconds for the optimization. Leave empty for not specifying a timeout (then, the best solution will be found no matter how long it takes).                                                                                                                  |
+| Border width            | The border pixels have to be treated in a special way for appearance/disappearance                                                                                                                                                                                      |
+| Transition neighborhood | How far can an object move                                                                                                                                                                                                                                              |
+| Frames per split        | By default (0) the tracking is done globally over the whole time range. By specifying a non-zero number here, you break your video up into pieces of this length and then solve hierarchically and in parallel. This is much faster than no splitting for long videos   |
+| Solver                  | Flow-based, as described [here](https://link.springer.com/chapter/10.1007/978-3-319-46478-7_35) or ILP, which requires commercial solvers. Flow-based gives excellent tracking solutions and is much faster than ILP, which we keep for consistency with older projects |
+| Divisible Objects       | Check if the objects may divide over time, e.g. when tracking proliferating cells. Consider using the animal tracking workflow if they don't.                                                                                                                           |
 
 Furthermore, a **Field of View** may be specified for the tracking. Restricting the field of view to less time steps 
 or a smaller volume may lead to significant speed-ups of the tracking. Moreover, a **Size** range can be set to filter out objects which are smaller or larger than the number of pixels specified.
@@ -431,21 +431,19 @@ this procedure is similar to the export of the fully automatic tracking.
 #### Shortcuts
 To most efficiently use the features described above, there are multiple shortcuts available:
 
-| Shortcut       | Description   
-|:--------------:| :-----------------------------
-| `Shift + Scroll` | Scroll image through time
-| `Ctrl + Scroll`| Zoom
-| `s`            | Start new track
-| `d`            | Mark division event
-| `f`            | Mark false detection
-| `q`            | Increment active track ID
-| `a`            | Decrement active track ID
-| `g`            | Go to next unlabeled object
-| `e`            | Toggle manual tracking layer visibility
-| `r`            | Toggle objects layer visibility
-
-
-
+{:.table.table-striped}
+| Shortcut         | Description                             |
+|:----------------:|:----------------------------------------|
+| `Shift + Scroll` | Scroll image through time               |
+| `Ctrl + Scroll`  | Zoom                                    |
+| `s`              | Start new track                         |
+| `d`              | Mark division event                     |
+| `f`              | Mark false detection                    |
+| `q`              | Increment active track ID               |
+| `a`              | Decrement active track ID               |
+| `g`              | Go to next unlabeled object             |
+| `e`              | Toggle manual tracking layer visibility |
+| `r`              | Toggle objects layer visibility         |
 
 ## 4.3 Structured Learning: <span class="hidden-in-sidebar" style="color:orange">&#9679;</span> {#sec_structured_learning}
 
@@ -514,14 +512,14 @@ The `object_ids` can be exported separately by right-clicking on the **Objects**
    division, merger). In each of these hdf5 files (except the one for the first time step), detected events
    between object identifiers (stored in the volume `/segmentation/labels`) are stored in the following format:
 
-| Event      | Dataset Name | Object IDs 
-|:----------|:------------| :-------------------------
-| Move      | `/tracking/Moves` | `from (previous timestep), to (current timestep)`
-| Division | `/tracking/Splits` | `ancestor (prev. timestep), descendant (cur. timestep), descendant (cur. timestep)`
-| Appearance | `/tracking/Appearances` | `object_id appeared in current timestep`
-| Disappearance | `/tracking/Disappearances` | `object_id disappeared in current timestep`
-| Merger | `/tracking/Mergers` | `object_id, number_of_contained_objects` 
-
+{:.table.table-striped}
+| Event         | Dataset Name               | Object IDs                                                            |
+|:--------------|:---------------------------|:----------------------------------------------------------------------|
+| Move          | `/tracking/Moves`          | `from` *previous timestep* &bull; `to` *current timestep*             |
+| Division      | `/tracking/Splits`         | `ancestor` *previous timestep* &bull; `descendant` *current timestep* |
+| Appearance    | `/tracking/Appearances`    | `object_id` appeared in current timestep                              |
+| Disappearance | `/tracking/Disappearances` | `object_id` disappeared in current timestep                           |
+| Merger        | `/tracking/Mergers`        | `object_id` &bull; `number_of_contained_objects`                      |
 
 We would recommend to use the methods described above, but additionally, the results of the manual **and** automatic tracking may also 
 be accessed via the ilastik project file:

--- a/documentation/tracking/tracking.md
+++ b/documentation/tracking/tracking.md
@@ -513,16 +513,13 @@ The `object_ids` can be exported separately by right-clicking on the **Objects**
    between object identifiers (stored in the volume `/segmentation/labels`) are stored in the following format:
 
 {:.table.table-striped}
-| Event           | Dataset Name                | Columns                                                                        |
-|-----------------|-----------------------------|--------------------------------------------------------------------------------|
-| Appearances     | `/tracking/Appearances`     | cell label appeared in current file                                            |
-| Disappearances  | `/tracking/Disappearances`  | cell label disappeared in current file                                         |
-| Moves           | `/tracking/Moves`           | from (previous file), to (current file)                                        |
-| Splits          | `/tracking/Splits`          | ancestor (previous file), descendant (current file), descendant (current file) |
-| Mergers         | `/tracking/Mergers`         | descendant (current file), number of objects                                   |
-| MultiFrameMoves | `/tracking/MultiFrameMoves` | from (file at t_from), to (current file), t_from                               |
-
-Each `/tracking/EVENT` dataset from the table above has a corresponding `/tracking/EVENT-Energy` dataset, where lower energy &rarr; higher confidence.
+| Event           | Dataset Name                | Columns                                                                                        |
+|-----------------|-----------------------------|------------------------------------------------------------------------------------------------|
+| Appearances     | `/tracking/Appearances`     | cell label appeared in current file                                                            |
+| Disappearances  | `/tracking/Disappearances`  | cell label disappeared in current file                                                         |
+| Moves           | `/tracking/Moves`           | from (previous file) &bull; to (current file)                                                  |
+| Splits          | `/tracking/Splits`          | ancestor (previous file) &bull; descendant 1 (current file) &bull; descendant 2 (current file) |
+| Mergers         | `/tracking/Mergers`         | descendant (current file) &bull; number of objects                                             |
 
 We would recommend to use the methods described above, but additionally, the results of the manual **and** automatic tracking may also 
 be accessed via the ilastik project file:

--- a/documentation/tracking/tracking.md
+++ b/documentation/tracking/tracking.md
@@ -522,7 +522,7 @@ The `object_ids` can be exported separately by right-clicking on the **Objects**
 | Mergers         | `/tracking/Mergers`         | descendant (current file), number of objects                                   |
 | MultiFrameMoves | `/tracking/MultiFrameMoves` | from (file at t_from), to (current file), t_from                               |
 
-Each dataset `/tracking/EVENT` from the table above also has a corresponding `/tracking/EVENT-Energy` dataset, where lower energy &rarr; high confidence.
+Each `/tracking/EVENT` dataset from the table above has a corresponding `/tracking/EVENT-Energy` dataset, where lower energy &rarr; higher confidence.
 
 We would recommend to use the methods described above, but additionally, the results of the manual **and** automatic tracking may also 
 be accessed via the ilastik project file:

--- a/documentation/tracking/tracking.md
+++ b/documentation/tracking/tracking.md
@@ -513,13 +513,16 @@ The `object_ids` can be exported separately by right-clicking on the **Objects**
    between object identifiers (stored in the volume `/segmentation/labels`) are stored in the following format:
 
 {:.table.table-striped}
-| Event         | Dataset Name               | Object IDs                                                            |
-|:--------------|:---------------------------|:----------------------------------------------------------------------|
-| Move          | `/tracking/Moves`          | `from` *previous timestep* &bull; `to` *current timestep*             |
-| Division      | `/tracking/Splits`         | `ancestor` *previous timestep* &bull; `descendant` *current timestep* |
-| Appearance    | `/tracking/Appearances`    | `object_id` appeared in current timestep                              |
-| Disappearance | `/tracking/Disappearances` | `object_id` disappeared in current timestep                           |
-| Merger        | `/tracking/Mergers`        | `object_id` &bull; `number_of_contained_objects`                      |
+| Event           | Dataset Name                | Columns                                                                        |
+|-----------------|-----------------------------|--------------------------------------------------------------------------------|
+| Appearances     | `/tracking/Appearances`     | cell label appeared in current file                                            |
+| Disappearances  | `/tracking/Disappearances`  | cell label disappeared in current file                                         |
+| Moves           | `/tracking/Moves`           | from (previous file), to (current file)                                        |
+| Splits          | `/tracking/Splits`          | ancestor (previous file), descendant (current file), descendant (current file) |
+| Mergers         | `/tracking/Mergers`         | descendant (current file), number of objects                                   |
+| MultiFrameMoves | `/tracking/MultiFrameMoves` | from (file at t_from), to (current file), t_from                               |
+
+Each dataset `/tracking/EVENT` from the table above also has a corresponding `/tracking/EVENT-Energy` dataset, where lower energy &rarr; high confidence.
 
 We would recommend to use the methods described above, but additionally, the results of the manual **and** automatic tracking may also 
 be accessed via the ilastik project file:


### PR DESCRIPTION
Markdown tables are generated without any classes, but Bootstrap
requires adding `.table` classes in order for a table to be styled.

Closes https://github.com/ilastik/ilastik.github.io/issues/151