### PR TITLE
Add note about no support for OSX 11.0

### DIFF
--- a/download.html
+++ b/download.html
@@ -53,7 +53,7 @@ Commercial solver support for cplex version 1290 and gurobi 811 for tracking wit
         <th><i class="fa fa-apple fa-lg"></i>&nbsp;Mac (64-bit), OSX</th>
         <td><a href="https://files.ilastik.org/ilastik-1.3.3post3-OSX.tar.bz2">version 1.3.3post3 (2020-05-03)</a>
           (<a href="https://oc.embl.de/index.php/s/uHCriC5Sh2XxxpW/download">mirror</a>)</td>
-        <td><b>Supported Versions:</b> 10.9 and up</td>
+        <td><b>Supported Versions:</b> 10.9 (Mavericks) up until 10.15 (Catalina). 11.0 (Big Sur) currently not supported.</td>
     </tr>
 </tbody>
 </table>
@@ -90,7 +90,7 @@ Commercial solver support for cplex version 1290 and gurobi 903 for tracking wit
     <tr>
         <th><i class="fa fa-apple fa-lg"></i>&nbsp;Mac (64-bit), OSX</th>
         <td><a href="https://files.ilastik.org/ilastik-1.4.0b8-OSX.tar.bz2">version 1.4.0b8</a></td>
-        <td><b>Supported Versions:</b> 10.9 and up</td>
+        <td><b>Supported Versions:</b> 10.9 (Mavericks) up until 10.15 (Catalina). 11.0 (Big Sur) currently not supported.</td>
     </tr>
 </tbody>
 </table>


### PR DESCRIPTION
Right now, we cannot support ilastik on OSX Big Sur. See https://github.com/ilastik/ilastik/issues/2344 and https://github.com/ilastik/ilastik/pull/2345

@akreshuk, we had the idea of warning our OSX users via a tweet?