### PR TITLE
Add style for youtube iframes

### DIFF
--- a/assets/ilastik.css
+++ b/assets/ilastik.css
@@ -180,3 +180,11 @@ h2:hover .header-link {
       overflow: hidden!important;
   }
 }
+
+/* correct sizing on mobile devices */
+iframe[src*=youtube] {
+    display: block;
+    margin: 0 auto;
+    max-width: 100%;
+    padding-bottom: 8px;
+}


### PR DESCRIPTION
fixes width for mobile devices

before:
<img width="433" alt="image" src="https://github.com/user-attachments/assets/963301b5-a0a2-47a4-addc-b1ff2699d744">


