### PR TITLE
Fix overflow of citation in about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -34,7 +34,6 @@ category: "About"
 
       <dt>How to cite</dt>
       <dd>The current ilastik version (1.0 and newer) is described in this Nature Methods Perspective:
-        <div class="container">
           <em>ilastik: interactive machine learning for (bio)image analysis</em><br>
           Stuart Berg, Dominik Kutra, Thorben Kroeger, Christoph N. Straehle, Bernhard X. Kausler,
           Carsten Haubold, Martin Schiegg, Janez Ales, Thorsten Beier, Markus Rudy, Kemal Eren,
@@ -43,7 +42,6 @@ category: "About"
           in: Nature Methods, (2019)
           <a href="https://www.nature.com/articles/s41592-019-0582-9">Link at publisher</a>,
           <a href="https://files.ilastik.org/ilastik-ref.bib">BibTex file</a>
-        </div>
       </dd>
 
       <dt>Other publications</dt>


### PR DESCRIPTION
before:
<img width="979" alt="image" src="https://github.com/user-attachments/assets/0cd695ce-bde0-4977-b3e0-76128c49bc49" />

with this PR
<img width="966" alt="image" src="https://github.com/user-attachments/assets/117fe217-b41f-46f3-bcb8-18e1d5961751" />
