### PR TITLE
Fix broken HDF5 link in documentation

### DIFF
--- a/documentation/basics/dataselection.md
+++ b/documentation/basics/dataselection.md
@@ -134,7 +134,7 @@ If you want to inspect a different scale later, you can use "Add new" and paste 
 
 ## Supported File Formats {#formats}
 
-The main file formats used by ilastik are [HDF5](https://portal.hdfgroup.org/display/HDF5/HDF5) and [N5](https://github.com/saalfeldlab/n5#n5--). Files with extensions `h5`, `hdf5`, `ilp` (ilastik project files) will be recognized as HDF5, folders with a `attributes.json` file will be recognized as `N5`.
+The main file formats used by ilastik are [HDF5](https://www.hdfgroup.org/solutions/hdf5/) and [N5](https://github.com/saalfeldlab/n5#n5--). Files with extensions `h5`, `hdf5`, `ilp` (ilastik project files) will be recognized as HDF5, folders with a `attributes.json` file will be recognized as `N5`.
 
 Widely used image formats such as
  * Microsoft Windows bitmap image file (`bmp`),


### PR DESCRIPTION
While going through the documentation, I noticed that the HDF5 link was broken
Since HDF5 is one of the main format used by ilastik, thought we should fix it

This PR fixes the issue by updating the link to one that I feel is the most appropriate (Please lmk if there is a better link)

Earlier it was showing

![Screenshot from 2025-03-20 12-28-32](https://github.com/user-attachments/assets/4de82cbd-fd37-4abf-ace6-6d0b79f9e2e6)
