### PR TITLE
Expand docs on OME-Zarr usage in 1.4.1

### DIFF
--- a/documentation/basics/dataselection.md
+++ b/documentation/basics/dataselection.md
@@ -30,6 +30,7 @@ New data can be imported in a project with the "Add New..." button.
 Clicking this will present two options,
  * Add separate image(s)...
  * Add a single 3D/4D Volume from Stack...
+ * Add multiscale dataset...
 
 These can be used to [load a 2D/3D/4D image from a single file](#single_file) or [load
 a single 2D/3D/4D image from a stack of 2D images](#image_stack) respectively.
@@ -110,13 +111,47 @@ This must be a full URL including protocol.
 When you click "Check", ilastik will try to obtain image metadata from the given address, and display the results of the request.
 If the dataset is stored on the local filesystem, you can paste the path into the address field, e.g. `C:\Users\me\Downloads\tissue-gfp.zarr`.
 The "Check" button will test whether the path exists on the filesystem and automatically convert it to a `file:///` URL if successful.
-Note that this has to be the path to the root of the dataset, i.e. the folder containing the `.zattrs` file, and the folder name has to contain ".zarr".
+
+If the check is successful, you can confirm by clicking "Add to project".
+You can then select which scale / resolution level to load using the drop-down box in the input data table.
 
 _Note: ilastik will freeze while waiting for a response. If the server is slow or the connection is bad, it may take a while and your computer might warn that ilastik is not responding._
 
-If the check is successful, you can confirm by clicking "Add to project". You can then select which scale /
-resolution level to load using the drop-down box in the input data table.
+### Finding the right URL for OME-Zarr datasets {#ome-zarr}
+Zarr is a generic container format that uses regular folders on the file system.
+The OME standard does not prescribe a certain folder structure for how to store images in Zarr containers.
+This means that "the multiscale dataset", and the individual scales, are just folders, and they might be stored inside higher-level containers.
+The folder naming does not always make it clear which is which.
 
+For ilastik, the address has to contain ".zarr".
+It doesn't matter which folder contains ".zarr" in its name, but it has to appear somewhere in the address.
+
+Additionally, the path or address pasted in the dialog in ilastik has to be the root of the dataset, i.e. the folder containing the `.zattrs` file.
+If in doubt, you can navigate deeper into the folder structure and try a lower-level address in ilastik.
+
+### Using multiscale datasets for secondary roles {#multiscale-secondary-role}
+Warning: The GUI is as of version 1.4.1 not optimized to deal with this.
+
+When choosing datasets for secondary roles, such as prediction maps or segmentation in Object Classification, the chosen dataset must match the shape of the Raw Data.
+The multiscale loader always defaults to the lowest-resolution scale.
+This means that unless you were working and exporting the lowest resolution of the raw data, the shape of the multiscale segmentation will mismatch.
+
+The current best way to work around this is to select the direct URL to the matching scale in the "Add multiscale dataset" dialog
+  ([instructions for finding the direct scale URL]({{site.baseurl}}/documentation/basics/headless#ome-zarr-input)).
+  For example: `https://s3.myserver.org/segmentations/tissue1-seg.zarr/s3`.
+
+### Accessing OME-Zarr datasets with authentication {#ome-zarr-auth}
+Datasets stored on Amazon Web Service's S3, or on S3-like servers, can be accessed in ilastik with or without authentication.
+If the dataset is publicly accessible, simply pasting the `https://` or `s3://` URL should be sufficient.
+
+For buckets requiring authentication, ilastik uses the module s3fs, which builds on Amazon's boto.
+You can find instructions on how to set up credentials in [the boto documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html).
+S3fs additionally implements authentication for S3-like servers via environment variables named `FSSPEC_...`, see the [s3fs docs](https://s3fs.readthedocs.io/en/latest/#s3-compatible-storage).
+
+When anonymous/public access fails, ilastik automatically tries AWS authentication for `s3://` URLs, and more generic s3fs authentication for `https://` URLs.
+If you cannot access your dataset from ilastik, but you are able to access it from other tools, please report this to us (`Help > Report issue`).
+
+### Browsing and working with multiscale datasets {#multiscale-browsing}
 To inspect more than one scale at a time, you can add multiple instances of the same dataset using "Add New".
 Simply paste the same address again, click "Check", and then "Add to project".
 

--- a/documentation/basics/export.md
+++ b/documentation/basics/export.md
@@ -27,7 +27,7 @@ In all workflows, there is a designated applet to export results (see, for examp
 ## Data Export Applet
 
 <div style="float: right; width: 60%" markdown="1">
-<a name="data-export-applet-ss" href="screenshots/export-applet.png" data-toggle="lightbox"><img src="screenshots/export_applet_with_source.png" class="img-responsive" /></a>
+<a name="data-export-applet-ss" href="screenshots/export_applet_with_source.png" data-toggle="lightbox"><img src="screenshots/export_applet_with_source.png" class="img-responsive" /></a>
 </div>
 
 The export step is handled through the data export applet in ilastik. In [pixel classification]({{baseurl}}/documentation/pixelclassification/pixelclassification.html), for example, the applet is called "Prediction Export".

--- a/documentation/basics/export.md
+++ b/documentation/basics/export.md
@@ -100,3 +100,19 @@ This means that if you continue using the exported data in other workflows, the 
 When you take these results into other tools, they may be able to match the data from ilastik to the corresponding scale of the source dataset.
 
 Additionally, if the source dataset was OME-Zarr, ilastik will carry over all pixel resolution metadata from the source dataset to the exported dataset.
+
+## Exporting OME-Zarr to cloud storage
+Exporting to cloud storage is possible, but this is in experimental stage and untested.
+Please proceed with caution.
+
+To export to cloud storage, simply open [the export settings dialog](#settings), select the OME-Zarr export format, and change the export path to the target URL.
+Magic placeholders like `{nickname}` and `{result_type}` will be replaced as usual for each dataset.
+
+For this to work, you must have write access to the target.
+We do not recommend opening a bucket for public write access.
+Instead, you should set up write permission for a specific user and then set up that user's credentials on your system as described in the [section on OME-Zarr access with authentication]({{baseurl}}/documentation/basics/dataselection.html#multiscale-ome-zarr-auth).
+Writing to AWS S3 with `s3://` URLs should generally work; writing to S3-like servers is not implemented yet (you will receive a "Forbidden" error).
+Please get in touch if you require this.
+
+As warned above, this is untested and not hardened to the various risks that come with uploading files over HTTPS.
+If any problems occur during the export, such as interruptions in the connection to the server, this will likely lead to unpredictable results.

--- a/documentation/basics/headless.md
+++ b/documentation/basics/headless.md
@@ -111,12 +111,13 @@ To use an OME-Zarr dataset in headless mode, you have to provide the full path t
                        --project=MyProject.ilp \
                        https://s3.embl.de/i2k-2020/platy-raw.ome.zarr/s6
 
-If you don't know the scale name, you can use the Input Data set of any ilastik workflow in the GUI to access the "Add multiscale" dialog.
+If you don't know the scale name, you can use the Input Data step of any ilastik workflow in the GUI to access the "Add multiscale dataset" dialog.
 Paste the root address and click "Check" to see the available scales.
 Alternatively, the specific dataset path for each scale is documented in the metadata found in the `.zattrs` file at the multiscale root.
 In the above example, this is at `https://s3.embl.de/i2k-2020/platy-raw.ome.zarr/.zattrs`.
 If there is no `.zattrs` file in your case, the dataset may be OME-Zarr version 0.5.
-In this case, the file is called `zarr.json` instead. OME-Zarr stores in this version are currently not supported by ilastik, however.
+In this case, the file is called `zarr.json` instead.
+OME-Zarr stores in this version are currently not supported by ilastik, however.
 
 ## Output Options {#output-options}
 

--- a/documentation/basics/headless.md
+++ b/documentation/basics/headless.md
@@ -39,21 +39,21 @@ Windows:
 
 **Note:** the following examples use linux shell syntax, but the options are the same for all platforms.
 
-### Important Notes:
+### Important Notes: {#notes}
 
 - Except for options passed with the `--export_source` argument (see below), don't specify any values with space-characters in them, even if inside quotes (e.g. `"my file name.h5"`, or `"(10, 20)"`). Due to a [bug in cpython](https://bugs.python.org/issue22433) those might be misinterpreted.
 - For paths to hdf5 datasests (either input or output), ilastik uses the same conventions as the generic [h5ls](https://support.hdfgroup.org/HDF5/Tutor/cmdtoolview.html#h5ls) utility. That is, the hdf5 dataset name should be appended to the file path: `/path/to/my_file.h5/internal/path/to/dataset`.
 - In the current "headless" implementation of object classification, the entire image is loaded into RAM in one go, and then object classification is run on it.  Therefore, there is a limit to how large your input image can be.
 - ilastik's command line options use underlines rather than dashes to separate words (e.g.: `--cutout_subregion` and not `--cutout-subregion`). If you mix them up, you might get strange errors. See [Known Issues](#known-issues) for more info.
 
-### Controlling RAM and CPU resources
+### Controlling RAM and CPU resources {#resources}
 
 By default, ilastik will use all available CPU cores (as detected by Python's "multiprocessing" module), including "virtual" cores if your CPU supports hyperthreading (like most modern Intel processors) and all RAM available on your machine.
 CPU and RAM resources can be controlled with environment variables or a config file as described [here][controlling resources].
 
 [controlling resources]: {{site.baseurl}}/documentation/basics/installation#controlling-cpu-and-ram-resources
 
-## Input options
+## Input options {#options}
 
 **Required settings:**
 
@@ -71,7 +71,7 @@ CPU and RAM resources can be controlled with environment variables or a config f
   Furthermore, if stack input is used, the input_axes define axes per slice.
 
 
-### Using hdf5 for memory efficiency
+### Using hdf5 for memory efficiency {#hdf5}
 
 We recommend to use hdf5 for input and output over, for example, TIF stacks. Indeed, TIF stacks cannot be written/read block-wise, hence the whole data has to be loaded and kept in memory. This can lead to excessive memory usage and slowness.
 
@@ -80,7 +80,7 @@ In order to convert your TIF slices into hdf5 datasets, you can check the dedica
 [fiji_plugin]: {{site.baseurl}}/documentation/fiji_export/plugin
 
 
-### Using stack input
+### Using stack input {#stack-input}
 
 If you are dealing with 3D data in the form of an image sequence (e.g. a tiff stack),
 then use globstring syntax to tell ilastik which images to combine for each volume.
@@ -101,7 +101,7 @@ So valid values for this option are `c`, `t`, and `z`, respectively.
 The `*` in each input argument must be provided to ilastik, NOT auto-expanded by the shell before ilastik sees the command!
 
 
-### Using OME-Zarr input
+### Using OME-Zarr input {#ome-zarr-input}
 
 OME-Zarr URIs are typically shared or provided pointing to the root of a multiscale dataset.
 The computations in any ilastik workflow can only run on a single scale, however.
@@ -118,7 +118,7 @@ In the above example, this is at `https://s3.embl.de/i2k-2020/platy-raw.ome.zarr
 If there is no `.zattrs` file in your case, the dataset may be OME-Zarr version 0.5.
 In this case, the file is called `zarr.json` instead. OME-Zarr stores in this version are currently not supported by ilastik, however.
 
-## Output Options
+## Output Options {#output-options}
 
 By default, ilastik will export the results in hdf5 format, stored to the same directory as the input image.
 However, you can customize the output location and format with extra parameters. For example:
@@ -157,7 +157,7 @@ the command (as shown in the example above).
 
 [Data Export Applet]: {{site.baseurl}}/documentation/basics/export.html#data-export-applet-ss
 
-## Headless Mode for Pixel Classification
+## Headless Mode for Pixel Classification {#pixel-classification}
 
 When running the Pixel Classification Workflow in headless mode, the available options for the `--export_source` flag are:
 
@@ -167,7 +167,7 @@ When running the Pixel Classification Workflow in headless mode, the available o
 - `Features`, which outputs a multi-channel image where each channel represents one of the computed pixel features;
 - `Labels`, which outputs an image representing the users' manually created annotations.
 
-## Headless Mode for Autocontext Workflow
+## Headless Mode for Autocontext Workflow {#autocontext}
 
 The [Autocontext]({{site.baseurl}}/documentation/autocontext/autocontext) workflow is essentially two runs of pixel classification, with the latter one using the output of the first one as an additional input. When running the Autocontext Workflow in headless mode, the available options for the `--export_source` are analogous to those of the simple Pixel Classification Workflow, but you can export the results of any of the two pixel classification stages involved in this workflow. Here's the full list of options:
 
@@ -185,7 +185,7 @@ The [Autocontext]({{site.baseurl}}/documentation/autocontext/autocontext) workfl
 - `"Input Stage 1"`: exports your raw input image that was fed into the first stage of the workflow;
 - `"Input Stage 2"`: exports the input received by the second Pixel Classification stage in the workflow.
 
-## Headless Mode for Object Classification
+## Headless Mode for Object Classification {#object-classification}
 
 When running the Object Classification Workflow in headless mode, the available options for the `--export_source` flag are:
 - `"Object Predictions"` (default when nothing is specified), which exports a label image of the object class predictions;
@@ -231,7 +231,7 @@ If you are processing more than one volume in a single command, provide all inpu
     --segmentation_image my_unclassified_objects_1.h5/binary_segmentation_volume my_unclassified_objects_2.h5/binary_segmentation_volume my_unclassified_objects_3.h5/binary_segmentation_volume
 
 
-## Headless Mode for Boundary-based Segmentation with Multicut
+## Headless Mode for Boundary-based Segmentation with Multicut {#multicut}
 
 When running the headless mode for the [Multicut Workflow], the following flags define the input data to be used:
 
@@ -255,7 +255,7 @@ An example invocation is given below:
 
 [Multicut Workflow]: {{site.baseurl}}/documentation/multicut/multicut.html
 
-## Headless Mode for Counting Workflow
+## Headless Mode for Counting Workflow {#counting}
 
 When running the Object Classification Workflow in headless mode, the only available option for the `--export_source` is `Probabilities`.
 
@@ -302,7 +302,7 @@ See the following example invocation that produces a csv-table via the plugin ex
     --export_plugin="CSV-Table" \
 ```
 
-## Running distributed ilastik via MPI (potentially trough SLURM)
+## Running distributed ilastik via MPI (potentially trough SLURM) {#mpi}
 
 You can run some ilastik headless workflows as a distributed MPI application. This is functionally equivalent to (though far more efficient than) invoking ilastik multiple times, each time with a different `--cutout_subregion`, and saving all those executions as tiles of a single `.n5` dataset.
 
@@ -341,7 +341,7 @@ To run ilastik distributed, you must invoke it either through `mpiexec` or `srun
                                     --raw-data=my_very_big_tiled_dataset.h5
 
 
-## Running your own Python scripts
+## Running your own Python scripts {#python}
 
 For developers and power-users, you can run your own ilastik-dependent python scripts using the interpreter shipped within the ilastik install tree.  The interpreter is located in the `bin` directory:
 
@@ -353,7 +353,7 @@ For developers and power-users, you can run your own ilastik-dependent python sc
     $ ./ilastik-1.3.2-OSX.app/Contents/ilastik-release/bin/python -c "import ilastik; print ilastik.__version__"
     1.3.2
 
-## Known Issues
+## Known Issues {#issues}
 
 ilastik's headless mode will sometimes throw exceptions and output a stack trace instead of letting you known why your command line arguments are wrong. Though those issues are being worked on, here are some hints and workarounds you can use to get by:
 


### PR DESCRIPTION
One thing that frustrates me a bit is the anchor button next to headings:
<img width="489" height="82" alt="image" src="https://github.com/user-attachments/assets/808c0379-3b4c-4d38-9150-9a2372f9f063" />

I would want these on all headings because it makes linking people to specific parts of the doc more convenient than opening the page source, but I can't figure out how to get them to work.