### PR TITLE
Clarify osx download warnings

### DIFF
--- a/download.html
+++ b/download.html
@@ -96,7 +96,7 @@ ilastik GPU-enabled builds are distributed with NVidia's CUDA toolkit. By downlo
 
 <div class="panel panel-danger">
   <div class="panel-heading">
-    <h3 class="panel-title">macOS compatibility note</a></h3>
+    <h3 class="panel-title">macOS compatibility note for ilastik version older than 1.4.0</a></h3>
   </div>
   <div class="panel-body">
     Starting with macOS 11 (Big Sur), or newer <em>ilastik versions
@@ -135,9 +135,8 @@ After you install the server part, you can use your regular ilastik installation
 <br>
 Commercial solver support with gurobi 951 for tracking with learning.
 
-Note that on OSX there is no 3D preview in Carving, all other functionality should work as expected.
-We recommend OSX users to download the current <a href="{{site.baseurl}}/download.html#beta">beta version</a>.
-If you have an Apple Silicon (M1/M2/M3), then please select the "Apple Silicon (arm64)" build.
+Note that in 1.4.0.post1 on OSX there is no 3D preview in Carving, all other functionality should work as expected.
+ilastik version 1.4.1 and newer have native builds for Apple Silicon (M1/M2/M3/M4) (download the "Apple Silicon (arm64)" build) with the 3D preview working as expected.
 
 <h5>Regular builds</h5>
 


### PR DESCRIPTION
@FynnBe made me aware that these warnings, while they made sense  at the time, could now be confusing.