### PR TITLE
Add links for 1.4.2b5

### DIFF
--- a/download.html
+++ b/download.html
@@ -92,6 +92,72 @@ ilastik GPU-enabled builds are distributed with NVidia's CUDA toolkit. By downlo
 <br>
 
 
+<h3 id="beta">Beta Version 1.4.2b5 (7. November 2025)</h3>
+
+<p><strong>Release Highlights:</strong></p>
+<ul>
+  <li>Physical pixel size metadata is now carried over from inputs to exports when using TIFF or H5</li>
+  <li>Viewer performance upgrade: Browsing big datasets should feel much smoother now</li>
+  <li>Pixel label explorer: Easily find and jump to previously drawn brush strokes</li>
+  <li>New "multi-scale OME-Zarr" export format and better UX when adding multiscale datasets to a project</li>
+  <li>New variant of Object Classification workflow, using a label image as the second input</li>
+</ul>
+
+<br>
+
+<h5>Regular builds</h5>
+
+<table class="table">
+  <tbody>
+  <tr>
+    <th><i class="fa fa-windows fa-lg"></i>&nbsp;Windows (64-bit)</th>
+    <td><a href="https://files.ilastik.org/ilastik-1.4.2b5-win64.exe">version 1.4.2b5 (504 MB)</a></td>
+    <td><b>Supported Versions:</b> Windows 10 and up</td>
+  </tr>
+  <tr>
+    <th><i class="fa fa-linux fa-lg"></i>&nbsp;Linux (64-bit)</th>
+    <td><a href="https://files.ilastik.org/ilastik-1.4.2b5-Linux.tar.bz2">version 1.4.2b5 (641 MB)</a></td>
+    <td><b>Supported Versions:</b> Ubuntu 14 and up </td>
+  </tr>
+  <tr>
+    <th><i class="fa fa-apple fa-lg"></i>&nbsp;Apple intel (64-bit), OSX</th>
+    <td><a href="https://files.ilastik.org/ilastik-1.4.2b5-OSX.zip">version 1.4.2b5 (899 MB)</a></td>
+    <td><b>Supported Versions:</b> 10.9 and up</td>
+  </tr>
+  <tr>
+    <th><i class="fa fa-apple fa-lg"></i>&nbsp;Apple Silicon (arm64), OSX</th>
+    <td><a href="https://files.ilastik.org/ilastik-1.4.2b5-arm64-OSX.zip">version 1.4.2b5 (645 MB)</a></td>
+    <td><b>Supported Versions:</b> 11 and up</td>
+  </tr>
+  </tbody>
+</table>
+
+<h5>GPU-enabled builds</h5>
+
+For faster neural network prediction.
+
+ilastik GPU-enabled builds are distributed with NVidia's CUDA toolkit. By downloading and using these builds, you accept the terms and conditions of the <a href="https://docs.nvidia.com/cuda/eula/index.html">CUDA End User License Agreement (EULA)</a>.
+
+<table class="table">
+  <tbody>
+  <tr>
+    <th><i class="fa fa-windows fa-lg"></i>&nbsp;Windows (64-bit)</th>
+    <td><a href="https://files.ilastik.org/ilastik-1.4.2b5-gpu-win64.7z.exe">version 1.4.2b5-gpu (2.2 GB)</a></td>
+    </td>
+    <td><b>Supported Versions:</b> Windows 10 and up, comes with cuda 12.6</td>
+  </tr>
+  <tr>
+    <th><i class="fa fa-linux fa-lg"></i>&nbsp;Linux (64-bit)</th>
+    <td><a href="https://files.ilastik.org/ilastik-1.4.2b5-gpu-Linux.tar.bz2">version 1.4.2b5-gpu (4.2 GB)</a></td>
+    <td><b>Supported Versions:</b> Ubuntu 14 and up, comes with cuda 12.6</td>
+  </tr>
+  </tbody>
+</table>
+
+<br>
+<br>
+
+
 <h3 id="previous">Previous stable versions</h3>
 
 <div class="panel panel-danger">


### PR DESCRIPTION
No notes section for now because I'm not aware of anything in addition to the existing 1.4.1 notes.